### PR TITLE
Set up queues + default queue worker

### DIFF
--- a/backends/src/queues.py
+++ b/backends/src/queues.py
@@ -1,0 +1,10 @@
+from redis import Redis
+from rq import Queue
+
+redis_cxn = Redis(host='queue', port=6379)
+
+content_queue = Queue('index_pdf_process_content', connection=redis_cxn)
+embeddings_queue = Queue('index_pdf_process_embeddings', connection=redis_cxn)
+extractions_queue = Queue('index_pdf_process_extractions', connection=redis_cxn)
+
+default_queue = Queue(connection=redis_cxn)

--- a/backends/src/worker.py
+++ b/backends/src/worker.py
@@ -1,0 +1,8 @@
+from redis import Redis
+from rq import Connection, Worker
+from queues import redis_cxn, default_queue
+
+if __name__ == '__main__':
+    with Connection(redis_cxn):
+        print('INFO (worker.py): worker starting on default_queue')
+        Worker(default_queue).work()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
   api:
     build:
       context: ./backends
+    image: api-image
     volumes:
       - ./backends/src:/usr/src/backends/src
       - ./backends/requirements.txt:/usr/src/backends/requirements.txt
@@ -81,3 +82,14 @@ services:
     image: redis:6.2.7
     ports:
       - "6379:6379"
+  
+  worker:
+    image: api-image:latest
+    volumes:
+      - ./backends/src:/usr/src/backends/src
+      - ./backends/requirements.txt:/usr/src/backends/requirements.txt
+    depends_on:
+      - queue
+    command: python -u src/worker.py
+    links:
+      - queue


### PR DESCRIPTION
This sets up RQ job queues. (Docs: https://python-rq.org/docs/)

To add a job to a queue:
```
import queues
from <module> import <func_to_queue>
...
job = queues.<queue_var>.enqueue(<func_to_queue>, <args>)
```